### PR TITLE
Fix types to remove unknown double cast problem

### DIFF
--- a/src/redux/fs/FSReducer.ts
+++ b/src/redux/fs/FSReducer.ts
@@ -1,7 +1,7 @@
 import { AnyAction, Reducer } from 'redux'
 import { download } from '.'
-import { YearsTaxesState } from '..'
 import { migrateEachYear } from '../migration'
+import { USTPersistedState } from '../store'
 import { FSAction } from './Actions'
 
 /**
@@ -12,7 +12,7 @@ import { FSAction } from './Actions'
  * It will overwrite whatever state exists with whatever
  * state it finds, but needs none of its own state.
  */
-const fsReducer = <S extends YearsTaxesState, A extends AnyAction>(
+const fsReducer = <S extends USTPersistedState, A extends AnyAction>(
   filename: string,
   reducer: Reducer<S, A>
 ): Reducer<S, A & FSAction<S>> => {

--- a/src/redux/migration.ts
+++ b/src/redux/migration.ts
@@ -1,14 +1,14 @@
 import { enumKeys } from 'ustaxes/core/util'
 import { TaxYears } from 'ustaxes/data'
-import { YearsTaxesState } from '.'
 import { blankState } from './reducer'
+import { USTPersistedState } from './store'
 
 /**
  * Ensures all default fields are present on each year's data
  * @returns state, mutated
  */
-export function migrateEachYear<S extends YearsTaxesState>(state: S): S {
-  return enumKeys(TaxYears).reduce(
+export const migrateEachYear = <S extends USTPersistedState>(state: S): S =>
+  enumKeys(TaxYears).reduce(
     (acc, year) => ({
       ...acc,
       [year]: {
@@ -18,4 +18,3 @@ export function migrateEachYear<S extends YearsTaxesState>(state: S): S {
     }),
     state
   )
-}


### PR DESCRIPTION
This is a proposed change to https://github.com/ustaxes/UsTaxes/pull/843. Merging it here will cause it to be appended to that PR.

The migrate parameter for `PersistReducer`'s config expects a type:

```
type PersistedState = undefined | { _persist: PersistState }
```

Note that this type cannot be unioned with anything because `undefined & S` is meaningless. So I just define a new type, `YearsTaxesState & { _persist: PersistState }`, and handle the undefined cases separately.